### PR TITLE
added support for Visual Studio C++

### DIFF
--- a/mapry/cpp/generate/jsoncpp_impl.py
+++ b/mapry/cpp/generate/jsoncpp_impl.py
@@ -277,7 +277,7 @@ def _duration_from_string() -> str:
             std::smatch mtch;
             const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-            if (not matched) {
+            if (!matched) {
                 std::stringstream sserr;
                 sserr << "failed to match the duration: " << s;
                 *error = sserr.str();
@@ -507,7 +507,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isBool()) {
+if (!{{ value }}.isBool()) {
     constexpr auto expected_but_got(
         "Expected a bool, but got: ");
 
@@ -558,7 +558,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}{# /value_expr|is_variable #}
-if (not {{ value }}.isInt64()) {
+if (!{{ value }}.isInt64()) {
     constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 
@@ -578,7 +578,7 @@ if (not {{ value }}.isInt64()) {
     {% if a_type.minimum is not none %}
 
     {% set op = ">" if a_type.exclusive_minimum else ">="  %}
-    if (not (cast_{{ uid }} {{ op }} {{ a_type.minimum }})) {
+    if (!(cast_{{ uid }} {{ op }} {{ a_type.minimum }})) {
         constexpr auto expected_but_got(
             "Expected "
             {{ "%s %d"|format(op, a_type.minimum)|escaped_str }}
@@ -596,7 +596,7 @@ if (not {{ value }}.isInt64()) {
     {% if a_type.maximum is not none %}
 
     {% set op = "<" if a_type.exclusive_maximum else "<=" %}
-    if (not (cast_{{ uid }} {{ op }} {{ a_type.maximum }})) {
+    if (!(cast_{{ uid }} {{ op }} {{ a_type.maximum }})) {
         constexpr auto expected_but_got(
             "Expected "
             {{ "%s %d"|format(op, a_type.maximum)|escaped_str }}
@@ -657,7 +657,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isDouble()) {
+if (!{{ value }}.isDouble()) {
     constexpr auto expected_but_got(
         "Expected a double, but got: ");
 
@@ -677,7 +677,7 @@ if (not {{ value }}.isDouble()) {
     {% if a_type.minimum is not none %}
 
     {% set op = ">" if a_type.exclusive_minimum else ">="  %}
-    if (not (cast_{{ uid }} {{ op }} {{ a_type.minimum }})) {
+    if (!(cast_{{ uid }} {{ op }} {{ a_type.minimum }})) {
         constexpr auto expected_but_got(
             "Expected "
             {{ "%s %f"|format(op, a_type.minimum)|escaped_str }}
@@ -695,7 +695,7 @@ if (not {{ value }}.isDouble()) {
     {% if a_type.maximum is not none %}
 
     {% set op = "<" if a_type.exclusive_maximum else "<=" %}
-    if (not (cast_{{ uid }} {{ op }} {{ a_type.maximum }})) {
+    if (!(cast_{{ uid }} {{ op }} {{ a_type.maximum }})) {
         constexpr auto expected_but_got(
             "Expected "
             {{ "%s %f"|format(op, a_type.maximum)|escaped_str }}
@@ -755,7 +755,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -775,7 +775,7 @@ if (not {{ value }}.isString()) {
     const std::string cast_{{ uid }} = {{ value }}.asString();
     bool ok_{{ uid }} = true;
 
-    if (not std::regex_match(cast_{{ uid }}, regex_{{ uid }})) {
+    if (!std::regex_match(cast_{{ uid }}, regex_{{ uid }})) {
         constexpr auto expected_but_got(
             "Expected to match "
             {{ a_type.pattern.pattern|escaped_str }}
@@ -834,7 +834,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -867,7 +867,7 @@ if (not {{ value }}.isString()) {
     const std::string cast_{{ uid }} = {{ value }}.asString();
     bool ok_{{ uid }} = true;
 
-    if (not std::regex_match(cast_{{ uid }}, regex)) {
+    if (!std::regex_match(cast_{{ uid }}, regex)) {
         constexpr auto expected_but_got(
             "Expected to match "
             {{ a_type.pattern.pattern|escaped_str }}
@@ -928,7 +928,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -975,7 +975,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1099,7 +1099,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1189,7 +1189,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1215,7 +1215,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1295,7 +1295,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1312,7 +1312,7 @@ if (not {{ value }}.isString()) {
     std::chrono::nanoseconds cast_{{ uid }} = duration_from_string(
         cast_{{ uid }}_str, &error_{{ uid }});
 
-    if (not error_{{ uid }}.empty()) {
+    if (!error_{{ uid }}.empty()) {
         constexpr auto invalid_duration(
             "Invalid duration: ");
 
@@ -1378,7 +1378,7 @@ for (const Json::Value& item_{{ uid }} : {{ value }}) {
     }
 }
 {% endset %}
-if (not {{ value }}.isArray()) {
+if (!{{ value }}.isArray()) {
     constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -1476,7 +1476,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isObject()) {
+if (!{{ value }}.isObject()) {
     constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -1552,7 +1552,7 @@ we don't end up with an unnecessary variable1 = variable2 statement.#}
 {% set value = "value_%s"|format(uid) %}
 const Json::Value& value_{{ uid }} = {{ value_expr }};
 {% endif %}
-if (not {{ value }}.isString()) {
+if (!{{ value }}.isString()) {
     constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1831,7 +1831,7 @@ _PARSE_PROPERTY_TPL = mapry.cpp.jinja2_env.ENV.from_string(
 ////
 
 {% if not a_property.optional %}
-if (not {{value_obj_expr}}.isMember({{a_property.json|escaped_str}})) {
+if (!{{value_obj_expr}}.isMember({{a_property.json|escaped_str}})) {
     errors->add(
         {{ ref_obj_parts|join_strings|indent|indent }},
         {{ "Property is missing: %s"|format(a_property.json)|escaped_str }});
@@ -1921,7 +1921,7 @@ void {{ composite.name|as_variable }}_from(
         std::string ref,
         {{ composite.name|as_composite }}* target,
         parse::Errors* errors) {
-    if (not value.isObject()) {
+    if (!value.isObject()) {
         constexpr auto expected_but_got(
             "Expected an object, but got: ");
 
@@ -1997,11 +1997,11 @@ void {{ graph.name|as_variable }}_from(
         throw std::invalid_argument("Unexpected null errors");
     }
 
-    if (not errors->empty()) {
+    if (!errors->empty()) {
         throw std::invalid_argument("Unexpected non-empty errors");
     }
 
-    if (not value.isObject()) {
+    if (!value.isObject()) {
         constexpr auto expected_but_got(
             "Expected an object, but got: ");
 
@@ -2030,7 +2030,7 @@ void {{ graph.name|as_variable }}_from(
     if (value.isMember({{ cls.plural|json_plural|escaped_str }})) {
         const Json::Value& obj = value[{{
             cls.plural|json_plural|escaped_str }}];
-        if (not obj.isObject()) {
+        if (!obj.isObject()) {
             constexpr auto expected_but_got(
                 "Expected an object, but got: ");
 
@@ -2051,7 +2051,7 @@ void {{ graph.name|as_variable }}_from(
                     cls.plural|as_field }}[it.name()] = std::move(instance);
                 {% endset %}
                 {% if cls.id_pattern is not none %}
-                if (not std::regex_match(
+                if (!std::regex_match(
                         it.name(),
                         {{ cls.name|as_variable }}_re::kID)) {
                     constexpr auto expected_but_got(
@@ -2083,7 +2083,7 @@ void {{ graph.name|as_variable }}_from(
 
     // Pre-allocating class instances is critical.
     // If the pre-allocation failed, we can not continue to parse the instances.
-    if (not errors->empty()) {
+    if (!errors->empty()) {
         return;
     }
 
@@ -2713,7 +2713,7 @@ Json::Value serialize_{{ graph.name|as_variable }}(
     {% endfor %}{# /for property_serializations #}
     {% for cls in graph.classes.values() %}
 
-    if (not {{ graph.name|as_variable }}.{{ cls.plural|as_variable }}.empty()) {
+    if (!{{ graph.name|as_variable }}.{{ cls.plural|as_variable }}.empty()) {
         Json::Value {{ cls.plural|as_variable }}_as_value;
         for (const auto& kv : {{
                 graph.name|as_variable }}.{{ cls.plural|as_variable }}) {

--- a/mapry/cpp/generate/parse_impl.py
+++ b/mapry/cpp/generate/parse_impl.py
@@ -26,7 +26,7 @@ def _parse_errors() -> str:
 
         void Errors::add(const std::string& ref, const std::string& message) {
             if (errors_.size() < cap_) {
-                errors_.emplace_back(Error{.ref = ref, .message = message});
+                errors_.emplace_back(Error{ref, message});
             }
         }
 

--- a/test_cases/cpp/boost_optional/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/boost_optional/cpp/test_generate/jsoncpp.cpp
@@ -71,11 +71,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -100,7 +100,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -114,7 +114,7 @@ void some_graph_from(
     } else {
       for (Json::ValueConstIterator it = obj.begin();
           it != obj.end(); ++it) {
-        if (not std::regex_match(
+        if (!std::regex_match(
             it.name(),
             empty_re::kID)) {
           constexpr auto expected_but_got(
@@ -144,7 +144,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -196,7 +196,7 @@ void some_graph_from(
 
   if (value.isMember("optional_reference")) {
     const Json::Value& value_0 = value["optional_reference"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -238,7 +238,7 @@ void some_graph_from(
 
   if (value.isMember("optional_path")) {
     const Json::Value& value_1 = value["optional_path"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -267,7 +267,7 @@ void some_graph_from(
   if (value.isMember("optional_array")) {
     target->optional_array.emplace();
     const Json::Value& value_2 = value["optional_array"];
-    if (not value_2.isArray()) {
+    if (!value_2.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -284,7 +284,7 @@ void some_graph_from(
       target_2.resize(value_2.size());
       size_t i_2 = 0;
       for (const Json::Value& item_2 : value_2) {
-        if (not item_2.isInt64()) {
+        if (!item_2.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 
@@ -321,7 +321,7 @@ void some_graph_from(
   if (value.isMember("optional_map")) {
     target->optional_map.emplace();
     const Json::Value& value_4 = value["optional_map"];
-    if (not value_4.isObject()) {
+    if (!value_4.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -337,7 +337,7 @@ void some_graph_from(
       std::map<std::string, int64_t>& target_4 = *target->optional_map;
       for (Json::ValueConstIterator it_4 = value_4.begin(); it_4 != value_4.end(); ++it_4) {
         const Json::Value& value_5 = *it_4;
-        if (not value_5.isInt64()) {
+        if (!value_5.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 
@@ -371,7 +371,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -423,7 +423,7 @@ Json::Value serialize_some_graph(
     some_graph_as_value["optional_map"] = std::move(target_1);
   }
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;

--- a/test_cases/cpp/boost_optional/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/boost_optional/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/class_error_causes_no_conflict/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/class_error_causes_no_conflict/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("errors")) {
     const Json::Value& obj = value["errors"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -170,7 +170,7 @@ void error_from(
     std::string ref,
     Error* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -194,7 +194,7 @@ Json::Value serialize_some_graph(
     const SomeGraph& some_graph) {
   Json::Value some_graph_as_value;
 
-  if (not some_graph.errors.empty()) {
+  if (!some_graph.errors.empty()) {
     Json::Value errors_as_value;
     for (const auto& kv : some_graph.errors) {
       const std::string& id = kv.first;

--- a/test_cases/cpp/class_error_causes_no_conflict/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/class_error_causes_no_conflict/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/datetime_library_date/date/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/datetime_library_date/date/cpp/test_generate/jsoncpp.cpp
@@ -67,11 +67,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -89,13 +89,13 @@ void some_graph_from(
   // Parse some_date
   ////
 
-  if (not value.isMember("some_date")) {
+  if (!value.isMember("some_date")) {
     errors->add(
       ref,
       "Property is missing: some_date");
   } else {
     const Json::Value& value_0 = value["some_date"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -139,13 +139,13 @@ void some_graph_from(
   // Parse formatless_date
   ////
 
-  if (not value.isMember("formatless_date")) {
+  if (!value.isMember("formatless_date")) {
     errors->add(
       ref,
       "Property is missing: formatless_date");
   } else {
     const Json::Value& value_1 = value["formatless_date"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/cpp/datetime_library_date/date/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/datetime_library_date/date/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/datetime_library_date/datetime/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/datetime_library_date/datetime/cpp/test_generate/jsoncpp.cpp
@@ -67,11 +67,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -89,13 +89,13 @@ void some_graph_from(
   // Parse some_datetime
   ////
 
-  if (not value.isMember("some_datetime")) {
+  if (!value.isMember("some_datetime")) {
     errors->add(
       ref,
       "Property is missing: some_datetime");
   } else {
     const Json::Value& value_0 = value["some_datetime"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -139,13 +139,13 @@ void some_graph_from(
   // Parse formatless_datetime
   ////
 
-  if (not value.isMember("formatless_datetime")) {
+  if (!value.isMember("formatless_datetime")) {
     errors->add(
       ref,
       "Property is missing: formatless_datetime");
   } else {
     const Json::Value& value_1 = value["formatless_datetime"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/cpp/datetime_library_date/datetime/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/datetime_library_date/datetime/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/datetime_library_date/optional_timezone/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/datetime_library_date/optional_timezone/cpp/test_generate/jsoncpp.cpp
@@ -67,11 +67,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -91,7 +91,7 @@ void some_graph_from(
 
   if (value.isMember("some_time_zone")) {
     const Json::Value& value_0 = value["some_time_zone"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/cpp/datetime_library_date/optional_timezone/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/datetime_library_date/optional_timezone/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/datetime_library_date/time/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/datetime_library_date/time/cpp/test_generate/jsoncpp.cpp
@@ -67,11 +67,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -89,13 +89,13 @@ void some_graph_from(
   // Parse some_time
   ////
 
-  if (not value.isMember("some_time")) {
+  if (!value.isMember("some_time")) {
     errors->add(
       ref,
       "Property is missing: some_time");
   } else {
     const Json::Value& value_0 = value["some_time"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -143,13 +143,13 @@ void some_graph_from(
   // Parse formatless_time
   ////
 
-  if (not value.isMember("formatless_time")) {
+  if (!value.isMember("formatless_time")) {
     errors->add(
       ref,
       "Property is missing: formatless_time");
   } else {
     const Json::Value& value_1 = value["formatless_time"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/cpp/datetime_library_date/time/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/datetime_library_date/time/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/datetime_library_date/timezone/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/datetime_library_date/timezone/cpp/test_generate/jsoncpp.cpp
@@ -67,11 +67,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -89,13 +89,13 @@ void some_graph_from(
   // Parse some_time_zone
   ////
 
-  if (not value.isMember("some_time_zone")) {
+  if (!value.isMember("some_time_zone")) {
     errors->add(
       ref,
       "Property is missing: some_time_zone");
   } else {
     const Json::Value& value_0 = value["some_time_zone"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/cpp/datetime_library_date/timezone/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/datetime_library_date/timezone/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/primitive_types/duration/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/primitive_types/duration/cpp/test_generate/jsoncpp.cpp
@@ -106,7 +106,7 @@ std::chrono::nanoseconds duration_from_string(
   std::smatch mtch;
   const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-  if (not matched) {
+  if (!matched) {
     std::stringstream sserr;
     sserr << "failed to match the duration: " << s;
     *error = sserr.str();
@@ -302,11 +302,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -324,13 +324,13 @@ void some_graph_from(
   // Parse some_duration
   ////
 
-  if (not value.isMember("some_duration")) {
+  if (!value.isMember("some_duration")) {
     errors->add(
       ref,
       "Property is missing: some_duration");
   } else {
     const Json::Value& value_0 = value["some_duration"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -348,7 +348,7 @@ void some_graph_from(
       std::chrono::nanoseconds cast_0 = duration_from_string(
         cast_0_str, &error_0);
 
-      if (not error_0.empty()) {
+      if (!error_0.empty()) {
         constexpr auto invalid_duration(
           "Invalid duration: ");
 

--- a/test_cases/cpp/primitive_types/duration/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/primitive_types/duration/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/primitive_types/float/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/primitive_types/float/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_float
   ////
 
-  if (not value.isMember("some_float")) {
+  if (!value.isMember("some_float")) {
     errors->add(
       ref,
       "Property is missing: some_float");
   } else {
     const Json::Value& value_0 = value["some_float"];
-    if (not value_0.isDouble()) {
+    if (!value_0.isDouble()) {
       constexpr auto expected_but_got(
         "Expected a double, but got: ");
 

--- a/test_cases/cpp/primitive_types/float/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/primitive_types/float/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/cpp/primitive_types/integer/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/cpp/primitive_types/integer/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_int
   ////
 
-  if (not value.isMember("some_int")) {
+  if (!value.isMember("some_int")) {
     errors->add(
       ref,
       "Property is missing: some_int");
   } else {
     const Json::Value& value_0 = value["some_int"];
-    if (not value_0.isInt64()) {
+    if (!value_0.isInt64()) {
       constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 

--- a/test_cases/cpp/primitive_types/integer/cpp/test_generate/parse.cpp
+++ b/test_cases/cpp/primitive_types/integer/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/docs/schema/introductory_example/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/docs/schema/introductory_example/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void pipeline_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void pipeline_from(
 
   if (value.isMember("persons")) {
     const Json::Value& obj = value["persons"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void pipeline_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -168,13 +168,13 @@ void pipeline_from(
   // Parse maintainer
   ////
 
-  if (not value.isMember("maintainer")) {
+  if (!value.isMember("maintainer")) {
     errors->add(
       ref,
       "Property is missing: maintainer");
   } else {
     const Json::Value& value_0 = value["maintainer"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -242,7 +242,7 @@ void person_from(
     std::string ref,
     Person* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -260,13 +260,13 @@ void person_from(
   // Parse full_name
   ////
 
-  if (not value.isMember("full_name")) {
+  if (!value.isMember("full_name")) {
     errors->add(
       ref,
       "Property is missing: full_name");
   } else {
     const Json::Value& value_0 = value["full_name"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -290,13 +290,13 @@ void person_from(
   // Parse birthday
   ////
 
-  if (not value.isMember("birthday")) {
+  if (!value.isMember("birthday")) {
     errors->add(
       ref,
       "Property is missing: birthday");
   } else {
     const Json::Value& value_1 = value["birthday"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -342,7 +342,7 @@ void person_from(
   // Parse address
   ////
 
-  if (not value.isMember("address")) {
+  if (!value.isMember("address")) {
     errors->add(
       ref,
       "Property is missing: address");
@@ -365,7 +365,7 @@ void address_from(
     std::string ref,
     Address* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -383,13 +383,13 @@ void address_from(
   // Parse text
   ////
 
-  if (not value.isMember("text")) {
+  if (!value.isMember("text")) {
     errors->add(
       ref,
       "Property is missing: text");
   } else {
     const Json::Value& value_0 = value["text"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -440,7 +440,7 @@ Json::Value serialize_pipeline(
 
   pipeline_as_value["maintainer"] = pipeline.maintainer->id;
 
-  if (not pipeline.persons.empty()) {
+  if (!pipeline.persons.empty()) {
     Json::Value persons_as_value;
     for (const auto& kv : pipeline.persons) {
       const std::string& id = kv.first;

--- a/test_cases/docs/schema/introductory_example/cpp/test_generate/parse.cpp
+++ b/test_cases/docs/schema/introductory_example/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/fails/invalid_types/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/fails/invalid_types/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_booleans
   ////
 
-  if (not value.isMember("array_of_booleans")) {
+  if (!value.isMember("array_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: array_of_booleans");
   } else {
     const Json::Value& value_0 = value["array_of_booleans"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isBool()) {
+        if (!item_0.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/array/fails/invalid_types/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/fails/invalid_types/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/maximum_size/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/maximum_size/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_booleans
   ////
 
-  if (not value.isMember("array_of_booleans")) {
+  if (!value.isMember("array_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: array_of_booleans");
   } else {
     const Json::Value& value_0 = value["array_of_booleans"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -123,7 +123,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isBool()) {
+        if (!item_0.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/array/maximum_size/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/maximum_size/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/minimum_size/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/minimum_size/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_booleans
   ////
 
-  if (not value.isMember("array_of_booleans")) {
+  if (!value.isMember("array_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: array_of_booleans");
   } else {
     const Json::Value& value_0 = value["array_of_booleans"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -123,7 +123,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isBool()) {
+        if (!item_0.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/array/minimum_size/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/minimum_size/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/array/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/array/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_arrays
   ////
 
-  if (not value.isMember("array_of_arrays")) {
+  if (!value.isMember("array_of_arrays")) {
     errors->add(
       ref,
       "Property is missing: array_of_arrays");
   } else {
     const Json::Value& value_0 = value["array_of_arrays"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isArray()) {
+        if (!item_0.isArray()) {
           constexpr auto expected_but_got(
             "Expected an array, but got: ");
 
@@ -129,7 +129,7 @@ void some_graph_from(
           target_1.resize(item_0.size());
           size_t i_1 = 0;
           for (const Json::Value& item_1 : item_0) {
-            if (not item_1.isBool()) {
+            if (!item_1.isBool()) {
               constexpr auto expected_but_got(
                 "Expected a bool, but got: ");
 

--- a/test_cases/general/array/of/array/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/array/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/boolean/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/boolean/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_booleans
   ////
 
-  if (not value.isMember("array_of_booleans")) {
+  if (!value.isMember("array_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: array_of_booleans");
   } else {
     const Json::Value& value_0 = value["array_of_booleans"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isBool()) {
+        if (!item_0.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/array/of/boolean/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/boolean/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/class_ref/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/class_ref/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -168,13 +168,13 @@ void some_graph_from(
   // Parse array_of_class_refs
   ////
 
-  if (not value.isMember("array_of_class_refs")) {
+  if (!value.isMember("array_of_class_refs")) {
     errors->add(
       ref,
       "Property is missing: array_of_class_refs");
   } else {
     const Json::Value& value_0 = value["array_of_class_refs"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -191,7 +191,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -245,7 +245,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -278,7 +278,7 @@ Json::Value serialize_some_graph(
   }
   some_graph_as_value["array_of_class_refs"] = std::move(target_0);
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;

--- a/test_cases/general/array/of/class_ref/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/class_ref/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/date/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/date/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_dates
   ////
 
-  if (not value.isMember("array_of_dates")) {
+  if (!value.isMember("array_of_dates")) {
     errors->add(
       ref,
       "Property is missing: array_of_dates");
   } else {
     const Json::Value& value_0 = value["array_of_dates"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/date/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/date/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/datetime/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/datetime/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_datetimes
   ////
 
-  if (not value.isMember("array_of_datetimes")) {
+  if (!value.isMember("array_of_datetimes")) {
     errors->add(
       ref,
       "Property is missing: array_of_datetimes");
   } else {
     const Json::Value& value_0 = value["array_of_datetimes"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/datetime/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/datetime/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/duration/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/duration/cpp/test_generate/jsoncpp.cpp
@@ -106,7 +106,7 @@ std::chrono::nanoseconds duration_from_string(
   std::smatch mtch;
   const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-  if (not matched) {
+  if (!matched) {
     std::stringstream sserr;
     sserr << "failed to match the duration: " << s;
     *error = sserr.str();
@@ -302,11 +302,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -324,13 +324,13 @@ void some_graph_from(
   // Parse array_of_durations
   ////
 
-  if (not value.isMember("array_of_durations")) {
+  if (!value.isMember("array_of_durations")) {
     errors->add(
       ref,
       "Property is missing: array_of_durations");
   } else {
     const Json::Value& value_0 = value["array_of_durations"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -347,7 +347,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -367,7 +367,7 @@ void some_graph_from(
           std::chrono::nanoseconds cast_1 = duration_from_string(
             cast_1_str, &error_1);
 
-          if (not error_1.empty()) {
+          if (!error_1.empty()) {
             constexpr auto invalid_duration(
               "Invalid duration: ");
 

--- a/test_cases/general/array/of/duration/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/duration/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/embed/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/embed/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_embeds
   ////
 
-  if (not value.isMember("array_of_embeds")) {
+  if (!value.isMember("array_of_embeds")) {
     errors->add(
       ref,
       "Property is missing: array_of_embeds");
   } else {
     const Json::Value& value_0 = value["array_of_embeds"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -137,7 +137,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 

--- a/test_cases/general/array/of/embed/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/embed/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/float/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/float/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_floats
   ////
 
-  if (not value.isMember("array_of_floats")) {
+  if (!value.isMember("array_of_floats")) {
     errors->add(
       ref,
       "Property is missing: array_of_floats");
   } else {
     const Json::Value& value_0 = value["array_of_floats"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isDouble()) {
+        if (!item_0.isDouble()) {
           constexpr auto expected_but_got(
             "Expected a double, but got: ");
 

--- a/test_cases/general/array/of/float/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/float/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/integer/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/integer/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_integers
   ////
 
-  if (not value.isMember("array_of_integers")) {
+  if (!value.isMember("array_of_integers")) {
     errors->add(
       ref,
       "Property is missing: array_of_integers");
   } else {
     const Json::Value& value_0 = value["array_of_integers"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isInt64()) {
+        if (!item_0.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 

--- a/test_cases/general/array/of/integer/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/integer/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/map/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/map/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_maps
   ////
 
-  if (not value.isMember("array_of_maps")) {
+  if (!value.isMember("array_of_maps")) {
     errors->add(
       ref,
       "Property is missing: array_of_maps");
   } else {
     const Json::Value& value_0 = value["array_of_maps"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isObject()) {
+        if (!item_0.isObject()) {
           constexpr auto expected_but_got(
             "Expected an object, but got: ");
 
@@ -128,7 +128,7 @@ void some_graph_from(
           std::map<std::string, bool>& target_1 = target_0.at(i_0);
           for (Json::ValueConstIterator it_1 = item_0.begin(); it_1 != item_0.end(); ++it_1) {
             const Json::Value& value_2 = *it_1;
-            if (not value_2.isBool()) {
+            if (!value_2.isBool()) {
               constexpr auto expected_but_got(
                 "Expected a bool, but got: ");
 

--- a/test_cases/general/array/of/map/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/map/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/path/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/path/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_paths
   ////
 
-  if (not value.isMember("array_of_paths")) {
+  if (!value.isMember("array_of_paths")) {
     errors->add(
       ref,
       "Property is missing: array_of_paths");
   } else {
     const Json::Value& value_0 = value["array_of_paths"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/path/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/path/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/string/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/string/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_strings
   ////
 
-  if (not value.isMember("array_of_strings")) {
+  if (!value.isMember("array_of_strings")) {
     errors->add(
       ref,
       "Property is missing: array_of_strings");
   } else {
     const Json::Value& value_0 = value["array_of_strings"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/string/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/string/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/time/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/time/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_times
   ////
 
-  if (not value.isMember("array_of_times")) {
+  if (!value.isMember("array_of_times")) {
     errors->add(
       ref,
       "Property is missing: array_of_times");
   } else {
     const Json::Value& value_0 = value["array_of_times"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/time/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/time/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/array/of/time_zone/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/array/of/time_zone/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse array_of_time_zones
   ////
 
-  if (not value.isMember("array_of_time_zones")) {
+  if (!value.isMember("array_of_time_zones")) {
     errors->add(
       ref,
       "Property is missing: array_of_time_zones");
   } else {
     const Json::Value& value_0 = value["array_of_time_zones"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isString()) {
+        if (!item_0.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/array/of/time_zone/cpp/test_generate/parse.cpp
+++ b/test_cases/general/array/of/time_zone/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/class/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/class/cpp/test_generate/jsoncpp.cpp
@@ -71,11 +71,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -100,7 +100,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -114,7 +114,7 @@ void some_graph_from(
     } else {
       for (Json::ValueConstIterator it = obj.begin();
           it != obj.end(); ++it) {
-        if (not std::regex_match(
+        if (!std::regex_match(
             it.name(),
             empty_re::kID)) {
           constexpr auto expected_but_got(
@@ -153,7 +153,7 @@ void some_graph_from(
 
   if (value.isMember("with_references")) {
     const Json::Value& obj = value["with_references"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -177,7 +177,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -266,13 +266,13 @@ void some_graph_from(
   // Parse global_reference_to_an_empty
   ////
 
-  if (not value.isMember("global_reference_to_an_empty")) {
+  if (!value.isMember("global_reference_to_an_empty")) {
     errors->add(
       ref,
       "Property is missing: global_reference_to_an_empty");
   } else {
     const Json::Value& value_0 = value["global_reference_to_an_empty"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -314,7 +314,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -335,7 +335,7 @@ void with_reference_from(
     std::string ref,
     WithReference* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -353,13 +353,13 @@ void with_reference_from(
   // Parse reference_to_an_empty
   ////
 
-  if (not value.isMember("reference_to_an_empty")) {
+  if (!value.isMember("reference_to_an_empty")) {
     errors->add(
       ref,
       "Property is missing: reference_to_an_empty");
   } else {
     const Json::Value& value_0 = value["reference_to_an_empty"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -399,13 +399,13 @@ void with_reference_from(
   // Parse array_of_empties
   ////
 
-  if (not value.isMember("array_of_empties")) {
+  if (!value.isMember("array_of_empties")) {
     errors->add(
       ref,
       "Property is missing: array_of_empties");
   } else {
     const Json::Value& value_1 = value["array_of_empties"];
-    if (not value_1.isArray()) {
+    if (!value_1.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -422,7 +422,7 @@ void with_reference_from(
       target_1.resize(value_1.size());
       size_t i_1 = 0;
       for (const Json::Value& item_1 : value_1) {
-        if (not item_1.isString()) {
+        if (!item_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -474,13 +474,13 @@ void with_reference_from(
   // Parse map_of_empties
   ////
 
-  if (not value.isMember("map_of_empties")) {
+  if (!value.isMember("map_of_empties")) {
     errors->add(
       ref,
       "Property is missing: map_of_empties");
   } else {
     const Json::Value& value_3 = value["map_of_empties"];
-    if (not value_3.isObject()) {
+    if (!value_3.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -496,7 +496,7 @@ void with_reference_from(
       std::map<std::string, Empty*>& target_3 = target->map_of_empties;
       for (Json::ValueConstIterator it_3 = value_3.begin(); it_3 != value_3.end(); ++it_3) {
         const Json::Value& value_4 = *it_3;
-        if (not value_4.isString()) {
+        if (!value_4.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -579,7 +579,7 @@ Json::Value serialize_some_graph(
 
   some_graph_as_value["global_reference_to_an_empty"] = some_graph.global_reference_to_an_empty->id;
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;
@@ -609,7 +609,7 @@ Json::Value serialize_some_graph(
     some_graph_as_value["empties"] = empties_as_value;
   }
 
-  if (not some_graph.with_references.empty()) {
+  if (!some_graph.with_references.empty()) {
     Json::Value with_references_as_value;
     for (const auto& kv : some_graph.with_references) {
       const std::string& id = kv.first;

--- a/test_cases/general/class/cpp/test_generate/parse.cpp
+++ b/test_cases/general/class/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/class_ref_in_embed/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/class_ref_in_embed/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -168,7 +168,7 @@ void some_graph_from(
   // Parse some_embed
   ////
 
-  if (not value.isMember("some_embed")) {
+  if (!value.isMember("some_embed")) {
     errors->add(
       ref,
       "Property is missing: some_embed");
@@ -192,7 +192,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -213,7 +213,7 @@ void embed_with_ref_from(
     std::string ref,
     EmbedWithRef* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -231,13 +231,13 @@ void embed_with_ref_from(
   // Parse reference_to_empty
   ////
 
-  if (not value.isMember("reference_to_empty")) {
+  if (!value.isMember("reference_to_empty")) {
     errors->add(
       ref,
       "Property is missing: reference_to_empty");
   } else {
     const Json::Value& value_0 = value["reference_to_empty"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -294,7 +294,7 @@ Json::Value serialize_some_graph(
 
   some_graph_as_value["some_embed"] = serialize_embed_with_ref(some_graph.some_embed);
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;

--- a/test_cases/general/class_ref_in_embed/cpp/test_generate/parse.cpp
+++ b/test_cases/general/class_ref_in_embed/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/embed/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/embed/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,7 +87,7 @@ void some_graph_from(
   // Parse some_embed
   ////
 
-  if (not value.isMember("some_embed")) {
+  if (!value.isMember("some_embed")) {
     errors->add(
       ref,
       "Property is missing: some_embed");
@@ -110,7 +110,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -130,7 +130,7 @@ void non_empty_from(
     std::string ref,
     NonEmpty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -148,7 +148,7 @@ void non_empty_from(
   // Parse empty
   ////
 
-  if (not value.isMember("empty")) {
+  if (!value.isMember("empty")) {
     errors->add(
       ref,
       "Property is missing: empty");

--- a/test_cases/general/embed/cpp/test_generate/parse.cpp
+++ b/test_cases/general/embed/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/forward_declaration/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/forward_declaration/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("some_classes")) {
     const Json::Value& obj = value["some_classes"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -127,7 +127,7 @@ void some_graph_from(
 
   if (value.isMember("other_classes")) {
     const Json::Value& obj = value["other_classes"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -151,7 +151,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -247,7 +247,7 @@ void some_class_from(
     std::string ref,
     SomeClass* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -265,13 +265,13 @@ void some_class_from(
   // Parse reference_other
   ////
 
-  if (not value.isMember("reference_other")) {
+  if (!value.isMember("reference_other")) {
     errors->add(
       ref,
       "Property is missing: reference_other");
   } else {
     const Json::Value& value_0 = value["reference_other"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -311,13 +311,13 @@ void some_class_from(
   // Parse array_of_others
   ////
 
-  if (not value.isMember("array_of_others")) {
+  if (!value.isMember("array_of_others")) {
     errors->add(
       ref,
       "Property is missing: array_of_others");
   } else {
     const Json::Value& value_1 = value["array_of_others"];
-    if (not value_1.isArray()) {
+    if (!value_1.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -334,7 +334,7 @@ void some_class_from(
       target_1.resize(value_1.size());
       size_t i_1 = 0;
       for (const Json::Value& item_1 : value_1) {
-        if (not item_1.isString()) {
+        if (!item_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -386,13 +386,13 @@ void some_class_from(
   // Parse map_of_others
   ////
 
-  if (not value.isMember("map_of_others")) {
+  if (!value.isMember("map_of_others")) {
     errors->add(
       ref,
       "Property is missing: map_of_others");
   } else {
     const Json::Value& value_3 = value["map_of_others"];
-    if (not value_3.isObject()) {
+    if (!value_3.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -408,7 +408,7 @@ void some_class_from(
       std::map<std::string, OtherClass*>& target_3 = target->map_of_others;
       for (Json::ValueConstIterator it_3 = value_3.begin(); it_3 != value_3.end(); ++it_3) {
         const Json::Value& value_4 = *it_3;
-        if (not value_4.isString()) {
+        if (!value_4.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -462,7 +462,7 @@ void other_class_from(
     std::string ref,
     OtherClass* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -480,13 +480,13 @@ void other_class_from(
   // Parse reference_some
   ////
 
-  if (not value.isMember("reference_some")) {
+  if (!value.isMember("reference_some")) {
     errors->add(
       ref,
       "Property is missing: reference_some");
   } else {
     const Json::Value& value_0 = value["reference_some"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -526,13 +526,13 @@ void other_class_from(
   // Parse array_of_somes
   ////
 
-  if (not value.isMember("array_of_somes")) {
+  if (!value.isMember("array_of_somes")) {
     errors->add(
       ref,
       "Property is missing: array_of_somes");
   } else {
     const Json::Value& value_1 = value["array_of_somes"];
-    if (not value_1.isArray()) {
+    if (!value_1.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -549,7 +549,7 @@ void other_class_from(
       target_1.resize(value_1.size());
       size_t i_1 = 0;
       for (const Json::Value& item_1 : value_1) {
-        if (not item_1.isString()) {
+        if (!item_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -601,13 +601,13 @@ void other_class_from(
   // Parse map_of_somes
   ////
 
-  if (not value.isMember("map_of_somes")) {
+  if (!value.isMember("map_of_somes")) {
     errors->add(
       ref,
       "Property is missing: map_of_somes");
   } else {
     const Json::Value& value_3 = value["map_of_somes"];
-    if (not value_3.isObject()) {
+    if (!value_3.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -623,7 +623,7 @@ void other_class_from(
       std::map<std::string, SomeClass*>& target_3 = target->map_of_somes;
       for (Json::ValueConstIterator it_3 = value_3.begin(); it_3 != value_3.end(); ++it_3) {
         const Json::Value& value_4 = *it_3;
-        if (not value_4.isString()) {
+        if (!value_4.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -724,7 +724,7 @@ Json::Value serialize_some_graph(
     const SomeGraph& some_graph) {
   Json::Value some_graph_as_value;
 
-  if (not some_graph.some_classes.empty()) {
+  if (!some_graph.some_classes.empty()) {
     Json::Value some_classes_as_value;
     for (const auto& kv : some_graph.some_classes) {
       const std::string& id = kv.first;
@@ -754,7 +754,7 @@ Json::Value serialize_some_graph(
     some_graph_as_value["some_classes"] = some_classes_as_value;
   }
 
-  if (not some_graph.other_classes.empty()) {
+  if (!some_graph.other_classes.empty()) {
     Json::Value other_classes_as_value;
     for (const auto& kv : some_graph.other_classes) {
       const std::string& id = kv.first;

--- a/test_cases/general/forward_declaration/cpp/test_generate/parse.cpp
+++ b/test_cases/general/forward_declaration/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/json_property/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/json_property/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_bool
   ////
 
-  if (not value.isMember("SOME-BOOL")) {
+  if (!value.isMember("SOME-BOOL")) {
     errors->add(
       ref,
       "Property is missing: SOME-BOOL");
   } else {
     const Json::Value& value_0 = value["SOME-BOOL"];
-    if (not value_0.isBool()) {
+    if (!value_0.isBool()) {
       constexpr auto expected_but_got(
         "Expected a bool, but got: ");
 

--- a/test_cases/general/json_property/cpp/test_generate/parse.cpp
+++ b/test_cases/general/json_property/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/invalid_type/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/invalid_type/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_booleans
   ////
 
-  if (not value.isMember("map_of_booleans")) {
+  if (!value.isMember("map_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: map_of_booleans");
   } else {
     const Json::Value& value_0 = value["map_of_booleans"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, bool>& target_0 = target->map_of_booleans;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isBool()) {
+        if (!value_1.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/map/invalid_type/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/invalid_type/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/array/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/array/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_arrays
   ////
 
-  if (not value.isMember("map_of_arrays")) {
+  if (!value.isMember("map_of_arrays")) {
     errors->add(
       ref,
       "Property is missing: map_of_arrays");
   } else {
     const Json::Value& value_0 = value["map_of_arrays"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, std::vector<bool>>& target_0 = target->map_of_arrays;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isArray()) {
+        if (!value_1.isArray()) {
           constexpr auto expected_but_got(
             "Expected an array, but got: ");
 
@@ -128,7 +128,7 @@ void some_graph_from(
           target_1.resize(value_1.size());
           size_t i_1 = 0;
           for (const Json::Value& item_1 : value_1) {
-            if (not item_1.isBool()) {
+            if (!item_1.isBool()) {
               constexpr auto expected_but_got(
                 "Expected a bool, but got: ");
 

--- a/test_cases/general/map/of/array/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/array/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/boolean/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/boolean/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_booleans
   ////
 
-  if (not value.isMember("map_of_booleans")) {
+  if (!value.isMember("map_of_booleans")) {
     errors->add(
       ref,
       "Property is missing: map_of_booleans");
   } else {
     const Json::Value& value_0 = value["map_of_booleans"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, bool>& target_0 = target->map_of_booleans;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isBool()) {
+        if (!value_1.isBool()) {
           constexpr auto expected_but_got(
             "Expected a bool, but got: ");
 

--- a/test_cases/general/map/of/boolean/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/boolean/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/class_ref/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/class_ref/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -168,13 +168,13 @@ void some_graph_from(
   // Parse map_of_class_refs
   ////
 
-  if (not value.isMember("map_of_class_refs")) {
+  if (!value.isMember("map_of_class_refs")) {
     errors->add(
       ref,
       "Property is missing: map_of_class_refs");
   } else {
     const Json::Value& value_0 = value["map_of_class_refs"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -190,7 +190,7 @@ void some_graph_from(
       std::map<std::string, Empty*>& target_0 = target->map_of_class_refs;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -242,7 +242,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -273,7 +273,7 @@ Json::Value serialize_some_graph(
   }
   some_graph_as_value["map_of_class_refs"] = std::move(target_0);
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;

--- a/test_cases/general/map/of/class_ref/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/class_ref/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/date/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/date/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_dates
   ////
 
-  if (not value.isMember("map_of_dates")) {
+  if (!value.isMember("map_of_dates")) {
     errors->add(
       ref,
       "Property is missing: map_of_dates");
   } else {
     const Json::Value& value_0 = value["map_of_dates"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, struct tm>& target_0 = target->map_of_dates;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/map/of/date/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/date/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/datetime/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/datetime/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_datetimes
   ////
 
-  if (not value.isMember("map_of_datetimes")) {
+  if (!value.isMember("map_of_datetimes")) {
     errors->add(
       ref,
       "Property is missing: map_of_datetimes");
   } else {
     const Json::Value& value_0 = value["map_of_datetimes"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, struct tm>& target_0 = target->map_of_datetimes;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/map/of/datetime/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/datetime/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/duration/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/duration/cpp/test_generate/jsoncpp.cpp
@@ -106,7 +106,7 @@ std::chrono::nanoseconds duration_from_string(
   std::smatch mtch;
   const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-  if (not matched) {
+  if (!matched) {
     std::stringstream sserr;
     sserr << "failed to match the duration: " << s;
     *error = sserr.str();
@@ -302,11 +302,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -324,13 +324,13 @@ void some_graph_from(
   // Parse map_of_durations
   ////
 
-  if (not value.isMember("map_of_durations")) {
+  if (!value.isMember("map_of_durations")) {
     errors->add(
       ref,
       "Property is missing: map_of_durations");
   } else {
     const Json::Value& value_0 = value["map_of_durations"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -346,7 +346,7 @@ void some_graph_from(
       std::map<std::string, std::chrono::nanoseconds>& target_0 = target->map_of_durations;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -366,7 +366,7 @@ void some_graph_from(
           std::chrono::nanoseconds cast_1 = duration_from_string(
             cast_1_str, &error_1);
 
-          if (not error_1.empty()) {
+          if (!error_1.empty()) {
             constexpr auto invalid_duration(
               "Invalid duration: ");
 

--- a/test_cases/general/map/of/duration/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/duration/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/embed/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/embed/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_embeds
   ////
 
-  if (not value.isMember("map_of_embeds")) {
+  if (!value.isMember("map_of_embeds")) {
     errors->add(
       ref,
       "Property is missing: map_of_embeds");
   } else {
     const Json::Value& value_0 = value["map_of_embeds"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -134,7 +134,7 @@ void someembed_from(
     std::string ref,
     SomeEmbed* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -152,13 +152,13 @@ void someembed_from(
   // Parse some_property
   ////
 
-  if (not value.isMember("some_property")) {
+  if (!value.isMember("some_property")) {
     errors->add(
       ref,
       "Property is missing: some_property");
   } else {
     const Json::Value& value_0 = value["some_property"];
-    if (not value_0.isBool()) {
+    if (!value_0.isBool()) {
       constexpr auto expected_but_got(
         "Expected a bool, but got: ");
 

--- a/test_cases/general/map/of/embed/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/embed/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/float/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/float/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_floats
   ////
 
-  if (not value.isMember("map_of_floats")) {
+  if (!value.isMember("map_of_floats")) {
     errors->add(
       ref,
       "Property is missing: map_of_floats");
   } else {
     const Json::Value& value_0 = value["map_of_floats"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, double>& target_0 = target->map_of_floats;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isDouble()) {
+        if (!value_1.isDouble()) {
           constexpr auto expected_but_got(
             "Expected a double, but got: ");
 

--- a/test_cases/general/map/of/float/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/float/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/integer/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/integer/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_integers
   ////
 
-  if (not value.isMember("map_of_integers")) {
+  if (!value.isMember("map_of_integers")) {
     errors->add(
       ref,
       "Property is missing: map_of_integers");
   } else {
     const Json::Value& value_0 = value["map_of_integers"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, int64_t>& target_0 = target->map_of_integers;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isInt64()) {
+        if (!value_1.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 

--- a/test_cases/general/map/of/integer/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/integer/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/map/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/map/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_maps
   ////
 
-  if (not value.isMember("map_of_maps")) {
+  if (!value.isMember("map_of_maps")) {
     errors->add(
       ref,
       "Property is missing: map_of_maps");
   } else {
     const Json::Value& value_0 = value["map_of_maps"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, std::map<std::string, bool>>& target_0 = target->map_of_maps;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isObject()) {
+        if (!value_1.isObject()) {
           constexpr auto expected_but_got(
             "Expected an object, but got: ");
 
@@ -127,7 +127,7 @@ void some_graph_from(
           std::map<std::string, bool>& target_1 = target_0[it_0.name()];
           for (Json::ValueConstIterator it_1 = value_1.begin(); it_1 != value_1.end(); ++it_1) {
             const Json::Value& value_2 = *it_1;
-            if (not value_2.isBool()) {
+            if (!value_2.isBool()) {
               constexpr auto expected_but_got(
                 "Expected a bool, but got: ");
 

--- a/test_cases/general/map/of/map/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/map/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/path/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/path/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_paths
   ////
 
-  if (not value.isMember("map_of_paths")) {
+  if (!value.isMember("map_of_paths")) {
     errors->add(
       ref,
       "Property is missing: map_of_paths");
   } else {
     const Json::Value& value_0 = value["map_of_paths"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, boost::filesystem::path>& target_0 = target->map_of_paths;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/map/of/path/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/path/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/string/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/string/cpp/test_generate/jsoncpp.cpp
@@ -66,11 +66,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -88,13 +88,13 @@ void some_graph_from(
   // Parse map_of_strings
   ////
 
-  if (not value.isMember("map_of_strings")) {
+  if (!value.isMember("map_of_strings")) {
     errors->add(
       ref,
       "Property is missing: map_of_strings");
   } else {
     const Json::Value& value_0 = value["map_of_strings"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -110,7 +110,7 @@ void some_graph_from(
       std::map<std::string, std::string>& target_0 = target->map_of_strings;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 
@@ -130,7 +130,7 @@ void some_graph_from(
           const std::string cast_1 = value_1.asString();
           bool ok_1 = true;
 
-          if (not std::regex_match(cast_1, regex_1)) {
+          if (!std::regex_match(cast_1, regex_1)) {
             constexpr auto expected_but_got(
               "Expected to match "
               "^hello.*$"

--- a/test_cases/general/map/of/string/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/string/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/map/of/time_zone/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/map/of/time_zone/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse map_of_time_zones
   ////
 
-  if (not value.isMember("map_of_time_zones")) {
+  if (!value.isMember("map_of_time_zones")) {
     errors->add(
       ref,
       "Property is missing: map_of_time_zones");
   } else {
     const Json::Value& value_0 = value["map_of_time_zones"];
-    if (not value_0.isObject()) {
+    if (!value_0.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       std::map<std::string, std::string>& target_0 = target->map_of_time_zones;
       for (Json::ValueConstIterator it_0 = value_0.begin(); it_0 != value_0.end(); ++it_0) {
         const Json::Value& value_1 = *it_0;
-        if (not value_1.isString()) {
+        if (!value_1.isString()) {
           constexpr auto expected_but_got(
             "Expected a string, but got: ");
 

--- a/test_cases/general/map/of/time_zone/cpp/test_generate/parse.cpp
+++ b/test_cases/general/map/of/time_zone/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/optional_in_class/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/optional_in_class/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -94,7 +94,7 @@ void some_graph_from(
 
   if (value.isMember("with_optionals")) {
     const Json::Value& obj = value["with_optionals"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -118,7 +118,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -170,7 +170,7 @@ void with_optional_from(
     std::string ref,
     WithOptional* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -190,7 +190,7 @@ void with_optional_from(
 
   if (value.isMember("some_text")) {
     const Json::Value& value_0 = value["some_text"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -226,7 +226,7 @@ Json::Value serialize_some_graph(
     const SomeGraph& some_graph) {
   Json::Value some_graph_as_value;
 
-  if (not some_graph.with_optionals.empty()) {
+  if (!some_graph.with_optionals.empty()) {
     Json::Value with_optionals_as_value;
     for (const auto& kv : some_graph.with_optionals) {
       const std::string& id = kv.first;

--- a/test_cases/general/optional_in_class/cpp/test_generate/parse.cpp
+++ b/test_cases/general/optional_in_class/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/optional_in_embed/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/optional_in_embed/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,7 +87,7 @@ void some_graph_from(
   // Parse some_property
   ////
 
-  if (not value.isMember("some_property")) {
+  if (!value.isMember("some_property")) {
     errors->add(
       ref,
       "Property is missing: some_property");
@@ -110,7 +110,7 @@ void with_optional_from(
     std::string ref,
     WithOptional* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -130,7 +130,7 @@ void with_optional_from(
 
   if (value.isMember("some_text")) {
     const Json::Value& value_0 = value["some_text"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/optional_in_embed/cpp/test_generate/parse.cpp
+++ b/test_cases/general/optional_in_embed/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/optional_in_graph/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/optional_in_graph/cpp/test_generate/jsoncpp.cpp
@@ -106,7 +106,7 @@ std::chrono::nanoseconds duration_from_string(
   std::smatch mtch;
   const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-  if (not matched) {
+  if (!matched) {
     std::stringstream sserr;
     sserr << "failed to match the duration: " << s;
     *error = sserr.str();
@@ -302,11 +302,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -331,7 +331,7 @@ void some_graph_from(
 
   if (value.isMember("empties")) {
     const Json::Value& obj = value["empties"];
-    if (not obj.isObject()) {
+    if (!obj.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -355,7 +355,7 @@ void some_graph_from(
 
   // Pre-allocating class instances is critical.
   // If the pre-allocation failed, we can not continue to parse the instances.
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     return;
   }
 
@@ -408,7 +408,7 @@ void some_graph_from(
   if (value.isMember("optional_array")) {
     target->optional_array.emplace();
     const Json::Value& value_0 = value["optional_array"];
-    if (not value_0.isArray()) {
+    if (!value_0.isArray()) {
       constexpr auto expected_but_got(
         "Expected an array, but got: ");
 
@@ -425,7 +425,7 @@ void some_graph_from(
       target_0.resize(value_0.size());
       size_t i_0 = 0;
       for (const Json::Value& item_0 : value_0) {
-        if (not item_0.isInt64()) {
+        if (!item_0.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 
@@ -461,7 +461,7 @@ void some_graph_from(
 
   if (value.isMember("optional_boolean")) {
     const Json::Value& value_2 = value["optional_boolean"];
-    if (not value_2.isBool()) {
+    if (!value_2.isBool()) {
       constexpr auto expected_but_got(
         "Expected a bool, but got: ");
 
@@ -487,7 +487,7 @@ void some_graph_from(
 
   if (value.isMember("optional_date")) {
     const Json::Value& value_3 = value["optional_date"];
-    if (not value_3.isString()) {
+    if (!value_3.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -535,7 +535,7 @@ void some_graph_from(
 
   if (value.isMember("optional_datetime")) {
     const Json::Value& value_4 = value["optional_datetime"];
-    if (not value_4.isString()) {
+    if (!value_4.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -583,7 +583,7 @@ void some_graph_from(
 
   if (value.isMember("optional_duration")) {
     const Json::Value& value_5 = value["optional_duration"];
-    if (not value_5.isString()) {
+    if (!value_5.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -601,7 +601,7 @@ void some_graph_from(
       std::chrono::nanoseconds cast_5 = duration_from_string(
         cast_5_str, &error_5);
 
-      if (not error_5.empty()) {
+      if (!error_5.empty()) {
         constexpr auto invalid_duration(
           "Invalid duration: ");
 
@@ -627,7 +627,7 @@ void some_graph_from(
 
   if (value.isMember("optional_float")) {
     const Json::Value& value_6 = value["optional_float"];
-    if (not value_6.isDouble()) {
+    if (!value_6.isDouble()) {
       constexpr auto expected_but_got(
         "Expected a double, but got: ");
 
@@ -653,7 +653,7 @@ void some_graph_from(
 
   if (value.isMember("optional_integer")) {
     const Json::Value& value_7 = value["optional_integer"];
-    if (not value_7.isInt64()) {
+    if (!value_7.isInt64()) {
       constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 
@@ -680,7 +680,7 @@ void some_graph_from(
   if (value.isMember("optional_map")) {
     target->optional_map.emplace();
     const Json::Value& value_8 = value["optional_map"];
-    if (not value_8.isObject()) {
+    if (!value_8.isObject()) {
       constexpr auto expected_but_got(
         "Expected an object, but got: ");
 
@@ -696,7 +696,7 @@ void some_graph_from(
       std::map<std::string, int64_t>& target_8 = *target->optional_map;
       for (Json::ValueConstIterator it_8 = value_8.begin(); it_8 != value_8.end(); ++it_8) {
         const Json::Value& value_9 = *it_8;
-        if (not value_9.isInt64()) {
+        if (!value_9.isInt64()) {
           constexpr auto expected_but_got(
             "Expected an int64, but got: ");
 
@@ -730,7 +730,7 @@ void some_graph_from(
 
   if (value.isMember("optional_path")) {
     const Json::Value& value_10 = value["optional_path"];
-    if (not value_10.isString()) {
+    if (!value_10.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -758,7 +758,7 @@ void some_graph_from(
 
   if (value.isMember("optional_string")) {
     const Json::Value& value_11 = value["optional_string"];
-    if (not value_11.isString()) {
+    if (!value_11.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -784,7 +784,7 @@ void some_graph_from(
 
   if (value.isMember("optional_time")) {
     const Json::Value& value_12 = value["optional_time"];
-    if (not value_12.isString()) {
+    if (!value_12.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -832,7 +832,7 @@ void some_graph_from(
 
   if (value.isMember("optional_time_zone")) {
     const Json::Value& value_13 = value["optional_time_zone"];
-    if (not value_13.isString()) {
+    if (!value_13.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -858,7 +858,7 @@ void some_graph_from(
 
   if (value.isMember("optional_reference")) {
     const Json::Value& value_14 = value["optional_reference"];
-    if (not value_14.isString()) {
+    if (!value_14.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -1028,7 +1028,7 @@ void empty_from(
     std::string ref,
     Empty* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -1048,7 +1048,7 @@ void some_embed_from(
     std::string ref,
     SomeEmbed* target,
     parse::Errors* errors) {
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -1151,7 +1151,7 @@ Json::Value serialize_some_graph(
     some_graph_as_value["optional_embed"] = serialize_some_embed((*some_graph.optional_embed));
   }
 
-  if (not some_graph.empties.empty()) {
+  if (!some_graph.empties.empty()) {
     Json::Value empties_as_value;
     for (const auto& kv : some_graph.empties) {
       const std::string& id = kv.first;

--- a/test_cases/general/optional_in_graph/cpp/test_generate/parse.cpp
+++ b/test_cases/general/optional_in_graph/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/boolean/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/boolean/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_bool
   ////
 
-  if (not value.isMember("some_bool")) {
+  if (!value.isMember("some_bool")) {
     errors->add(
       ref,
       "Property is missing: some_bool");
   } else {
     const Json::Value& value_0 = value["some_bool"];
-    if (not value_0.isBool()) {
+    if (!value_0.isBool()) {
       constexpr auto expected_but_got(
         "Expected a bool, but got: ");
 

--- a/test_cases/general/primitive_type/boolean/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/boolean/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/date/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/date/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_date
   ////
 
-  if (not value.isMember("some_date")) {
+  if (!value.isMember("some_date")) {
     errors->add(
       ref,
       "Property is missing: some_date");
   } else {
     const Json::Value& value_0 = value["some_date"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -139,13 +139,13 @@ void some_graph_from(
   // Parse formatless_date
   ////
 
-  if (not value.isMember("formatless_date")) {
+  if (!value.isMember("formatless_date")) {
     errors->add(
       ref,
       "Property is missing: formatless_date");
   } else {
     const Json::Value& value_1 = value["formatless_date"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/date/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/date/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/datetime/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/datetime/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_datetime
   ////
 
-  if (not value.isMember("some_datetime")) {
+  if (!value.isMember("some_datetime")) {
     errors->add(
       ref,
       "Property is missing: some_datetime");
   } else {
     const Json::Value& value_0 = value["some_datetime"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -139,13 +139,13 @@ void some_graph_from(
   // Parse formatless_datetime
   ////
 
-  if (not value.isMember("formatless_datetime")) {
+  if (!value.isMember("formatless_datetime")) {
     errors->add(
       ref,
       "Property is missing: formatless_datetime");
   } else {
     const Json::Value& value_1 = value["formatless_datetime"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/datetime/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/datetime/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/duration/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/duration/cpp/test_generate/jsoncpp.cpp
@@ -106,7 +106,7 @@ std::chrono::nanoseconds duration_from_string(
   std::smatch mtch;
   const bool matched = std::regex_match(s, mtch, re::kDuration);
 
-  if (not matched) {
+  if (!matched) {
     std::stringstream sserr;
     sserr << "failed to match the duration: " << s;
     *error = sserr.str();
@@ -302,11 +302,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -324,13 +324,13 @@ void some_graph_from(
   // Parse some_duration
   ////
 
-  if (not value.isMember("some_duration")) {
+  if (!value.isMember("some_duration")) {
     errors->add(
       ref,
       "Property is missing: some_duration");
   } else {
     const Json::Value& value_0 = value["some_duration"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -348,7 +348,7 @@ void some_graph_from(
       std::chrono::nanoseconds cast_0 = duration_from_string(
         cast_0_str, &error_0);
 
-      if (not error_0.empty()) {
+      if (!error_0.empty()) {
         constexpr auto invalid_duration(
           "Invalid duration: ");
 

--- a/test_cases/general/primitive_type/duration/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/duration/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/float/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/float/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_float_gt_0_lt_100
   ////
 
-  if (not value.isMember("some_float_gt_0_lt_100")) {
+  if (!value.isMember("some_float_gt_0_lt_100")) {
     errors->add(
       ref,
       "Property is missing: some_float_gt_0_lt_100");
   } else {
     const Json::Value& value_0 = value["some_float_gt_0_lt_100"];
-    if (not value_0.isDouble()) {
+    if (!value_0.isDouble()) {
       constexpr auto expected_but_got(
         "Expected a double, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       const auto cast_0 = value_0.asDouble();
       bool ok_0 = true;
 
-      if (not (cast_0 > 0)) {
+      if (!(cast_0 > 0)) {
         constexpr auto expected_but_got(
           "Expected "
           "> 0.000000"
@@ -125,7 +125,7 @@ void some_graph_from(
         ok_0 = false;
       }
 
-      if (not (cast_0 < 100)) {
+      if (!(cast_0 < 100)) {
         constexpr auto expected_but_got(
           "Expected "
           "< 100.000000"
@@ -154,13 +154,13 @@ void some_graph_from(
   // Parse some_float_ge_0_le_100
   ////
 
-  if (not value.isMember("some_float_ge_0_le_100")) {
+  if (!value.isMember("some_float_ge_0_le_100")) {
     errors->add(
       ref,
       "Property is missing: some_float_ge_0_le_100");
   } else {
     const Json::Value& value_1 = value["some_float_ge_0_le_100"];
-    if (not value_1.isDouble()) {
+    if (!value_1.isDouble()) {
       constexpr auto expected_but_got(
         "Expected a double, but got: ");
 
@@ -176,7 +176,7 @@ void some_graph_from(
       const auto cast_1 = value_1.asDouble();
       bool ok_1 = true;
 
-      if (not (cast_1 >= 0)) {
+      if (!(cast_1 >= 0)) {
         constexpr auto expected_but_got(
           "Expected "
           ">= 0.000000"
@@ -192,7 +192,7 @@ void some_graph_from(
         ok_1 = false;
       }
 
-      if (not (cast_1 <= 100)) {
+      if (!(cast_1 <= 100)) {
         constexpr auto expected_but_got(
           "Expected "
           "<= 100.000000"
@@ -221,13 +221,13 @@ void some_graph_from(
   // Parse unconstrained_float
   ////
 
-  if (not value.isMember("unconstrained_float")) {
+  if (!value.isMember("unconstrained_float")) {
     errors->add(
       ref,
       "Property is missing: unconstrained_float");
   } else {
     const Json::Value& value_2 = value["unconstrained_float"];
-    if (not value_2.isDouble()) {
+    if (!value_2.isDouble()) {
       constexpr auto expected_but_got(
         "Expected a double, but got: ");
 

--- a/test_cases/general/primitive_type/float/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/float/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/integer/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/integer/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_int_gt_0_lt_100
   ////
 
-  if (not value.isMember("some_int_gt_0_lt_100")) {
+  if (!value.isMember("some_int_gt_0_lt_100")) {
     errors->add(
       ref,
       "Property is missing: some_int_gt_0_lt_100");
   } else {
     const Json::Value& value_0 = value["some_int_gt_0_lt_100"];
-    if (not value_0.isInt64()) {
+    if (!value_0.isInt64()) {
       constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 
@@ -109,7 +109,7 @@ void some_graph_from(
       const auto cast_0 = value_0.asInt64();
       bool ok_0 = true;
 
-      if (not (cast_0 > 0)) {
+      if (!(cast_0 > 0)) {
         constexpr auto expected_but_got(
           "Expected "
           "> 0"
@@ -125,7 +125,7 @@ void some_graph_from(
         ok_0 = false;
       }
 
-      if (not (cast_0 < 100)) {
+      if (!(cast_0 < 100)) {
         constexpr auto expected_but_got(
           "Expected "
           "< 100"
@@ -154,13 +154,13 @@ void some_graph_from(
   // Parse some_int_ge_0_le_100
   ////
 
-  if (not value.isMember("some_int_ge_0_le_100")) {
+  if (!value.isMember("some_int_ge_0_le_100")) {
     errors->add(
       ref,
       "Property is missing: some_int_ge_0_le_100");
   } else {
     const Json::Value& value_1 = value["some_int_ge_0_le_100"];
-    if (not value_1.isInt64()) {
+    if (!value_1.isInt64()) {
       constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 
@@ -176,7 +176,7 @@ void some_graph_from(
       const auto cast_1 = value_1.asInt64();
       bool ok_1 = true;
 
-      if (not (cast_1 >= 0)) {
+      if (!(cast_1 >= 0)) {
         constexpr auto expected_but_got(
           "Expected "
           ">= 0"
@@ -192,7 +192,7 @@ void some_graph_from(
         ok_1 = false;
       }
 
-      if (not (cast_1 <= 100)) {
+      if (!(cast_1 <= 100)) {
         constexpr auto expected_but_got(
           "Expected "
           "<= 100"
@@ -221,13 +221,13 @@ void some_graph_from(
   // Parse unconstrained_int
   ////
 
-  if (not value.isMember("unconstrained_int")) {
+  if (!value.isMember("unconstrained_int")) {
     errors->add(
       ref,
       "Property is missing: unconstrained_int");
   } else {
     const Json::Value& value_2 = value["unconstrained_int"];
-    if (not value_2.isInt64()) {
+    if (!value_2.isInt64()) {
       constexpr auto expected_but_got(
         "Expected an int64, but got: ");
 

--- a/test_cases/general/primitive_type/integer/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/integer/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/path/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/path/cpp/test_generate/jsoncpp.cpp
@@ -66,11 +66,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -88,13 +88,13 @@ void some_graph_from(
   // Parse some_path
   ////
 
-  if (not value.isMember("some_path")) {
+  if (!value.isMember("some_path")) {
     errors->add(
       ref,
       "Property is missing: some_path");
   } else {
     const Json::Value& value_0 = value["some_path"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -112,7 +112,7 @@ void some_graph_from(
       const std::string cast_0 = value_0.asString();
       bool ok_0 = true;
 
-      if (not std::regex_match(cast_0, regex)) {
+      if (!std::regex_match(cast_0, regex)) {
         constexpr auto expected_but_got(
           "Expected to match "
           "^/[a-zA-Z]+-[0-9]+$"
@@ -143,13 +143,13 @@ void some_graph_from(
   // Parse unconstrained_path
   ////
 
-  if (not value.isMember("unconstrained_path")) {
+  if (!value.isMember("unconstrained_path")) {
     errors->add(
       ref,
       "Property is missing: unconstrained_path");
   } else {
     const Json::Value& value_1 = value["unconstrained_path"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/path/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/path/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/string/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/string/cpp/test_generate/jsoncpp.cpp
@@ -66,11 +66,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -88,13 +88,13 @@ void some_graph_from(
   // Parse some_str
   ////
 
-  if (not value.isMember("some_str")) {
+  if (!value.isMember("some_str")) {
     errors->add(
       ref,
       "Property is missing: some_str");
   } else {
     const Json::Value& value_0 = value["some_str"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -112,7 +112,7 @@ void some_graph_from(
       const std::string cast_0 = value_0.asString();
       bool ok_0 = true;
 
-      if (not std::regex_match(cast_0, regex_0)) {
+      if (!std::regex_match(cast_0, regex_0)) {
         constexpr auto expected_but_got(
           "Expected to match "
           "^[a-zA-Z]*$"
@@ -141,13 +141,13 @@ void some_graph_from(
   // Parse unconstrained_str
   ////
 
-  if (not value.isMember("unconstrained_str")) {
+  if (!value.isMember("unconstrained_str")) {
     errors->add(
       ref,
       "Property is missing: unconstrained_str");
   } else {
     const Json::Value& value_1 = value["unconstrained_str"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/string/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/string/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/time/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/time/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_time
   ////
 
-  if (not value.isMember("some_time")) {
+  if (!value.isMember("some_time")) {
     errors->add(
       ref,
       "Property is missing: some_time");
   } else {
     const Json::Value& value_0 = value["some_time"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 
@@ -139,13 +139,13 @@ void some_graph_from(
   // Parse formatless_time
   ////
 
-  if (not value.isMember("formatless_time")) {
+  if (!value.isMember("formatless_time")) {
     errors->add(
       ref,
       "Property is missing: formatless_time");
   } else {
     const Json::Value& value_1 = value["formatless_time"];
-    if (not value_1.isString()) {
+    if (!value_1.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/time/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/time/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 

--- a/test_cases/general/primitive_type/time_zone/cpp/test_generate/jsoncpp.cpp
+++ b/test_cases/general/primitive_type/time_zone/cpp/test_generate/jsoncpp.cpp
@@ -65,11 +65,11 @@ void some_graph_from(
     throw std::invalid_argument("Unexpected null errors");
   }
 
-  if (not errors->empty()) {
+  if (!errors->empty()) {
     throw std::invalid_argument("Unexpected non-empty errors");
   }
 
-  if (not value.isObject()) {
+  if (!value.isObject()) {
     constexpr auto expected_but_got(
       "Expected an object, but got: ");
 
@@ -87,13 +87,13 @@ void some_graph_from(
   // Parse some_time_zone
   ////
 
-  if (not value.isMember("some_time_zone")) {
+  if (!value.isMember("some_time_zone")) {
     errors->add(
       ref,
       "Property is missing: some_time_zone");
   } else {
     const Json::Value& value_0 = value["some_time_zone"];
-    if (not value_0.isString()) {
+    if (!value_0.isString()) {
       constexpr auto expected_but_got(
         "Expected a string, but got: ");
 

--- a/test_cases/general/primitive_type/time_zone/cpp/test_generate/parse.cpp
+++ b/test_cases/general/primitive_type/time_zone/cpp/test_generate/parse.cpp
@@ -18,7 +18,7 @@ void Errors::reserve(size_t expected_errors) {
 
 void Errors::add(const std::string& ref, const std::string& message) {
   if (errors_.size() < cap_) {
-    errors_.emplace_back(Error{.ref = ref, .message = message});
+    errors_.emplace_back(Error{ref, message});
   }
 }
 


### PR DESCRIPTION
This commits changes the C++ code generation so that the generated code complies with Visual Studio C++. Unfortunately, Visual Studio C++ does not conform to some of the standard C++ language constructs such as named struct initialization and alternative operator tokens (*e.g.*, "not" for "!").