### PR TITLE
Adapted for Windows

### DIFF
--- a/mapry/parse.py
+++ b/mapry/parse.py
@@ -385,8 +385,7 @@ def schema_from_json_file(path: pathlib.Path) -> mapry.Schema:
 
         try:
             obj = json.load(fp=fid, object_pairs_hook=_OrderedDictPP)
-            return schema_from_mapping(
-                mapping=obj, ref='{}#'.format(path.as_posix()))
+            return schema_from_mapping(mapping=obj, ref='{}#'.format(str(path)))
         except json.JSONDecodeError as err:
             jsonerr = err
 

--- a/precommit.py
+++ b/precommit.py
@@ -38,19 +38,19 @@ def main() -> int:
         subprocess.check_call([
             "yapf", "--in-place", "--style=style.yapf", "--recursive",
             "tests", "mapry", "setup.py", "precommit.py"],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
         # yapf: enable
     else:
         # yapf: disable
         subprocess.check_call([
             "yapf", "--diff", "--style=style.yapf", "--recursive",
             "tests", "mapry", "setup.py", "precommit.py"],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
         # yapf: enable
 
     print("Mypy'ing...")
     subprocess.check_call(["mypy", "--strict", "mapry", "tests"],
-                          cwd=repo_root.as_posix())
+                          cwd=str(repo_root))
 
     print("Isort'ing...")
     # yapf: disable
@@ -86,11 +86,11 @@ def main() -> int:
         subprocess.check_call(cmd)
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "mapry"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pydocstyle", "mapry"], cwd=str(repo_root))
 
     print("Pylint'ing...")
     subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "mapry"],
-                          cwd=repo_root.as_posix())
+                          cwd=str(repo_root))
 
     print("Testing...")
     env = os.environ.copy()
@@ -101,7 +101,7 @@ def main() -> int:
         ["coverage", "run",
          "--source", "mapry",
          "-m", "unittest", "discover", "tests"],
-        cwd=repo_root.as_posix(),
+        cwd=str(repo_root),
         env=env)
     # yapf: enable
 
@@ -109,21 +109,21 @@ def main() -> int:
 
     print("Doctesting...")
     subprocess.check_call(
-        ["python3", "-m", "doctest", (repo_root / "README.rst").as_posix()])
+        [sys.executable, "-m", "doctest",
+         str(repo_root / "README.rst")])
 
     for pth in sorted((repo_root / "mapry").glob("**/*.py")):
-        subprocess.check_call(["python3", "-m", "doctest", pth.as_posix()])
+        subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
 
     print("pyicontract-lint'ing...")
     for pth in sorted((repo_root / "mapry").glob("**/*.py")):
-        subprocess.check_call(["pyicontract-lint", pth.as_posix()])
+        subprocess.check_call(["pyicontract-lint", str(pth)])
 
     print("Checking with twine ...")
-    subprocess.check_call(["python3", "setup.py", "sdist"],
-                          cwd=repo_root.as_posix())
+    subprocess.check_call([sys.executable, "setup.py", "sdist"],
+                          cwd=str(repo_root))
 
-    subprocess.check_call(["twine", "check", "dist/*"],
-                          cwd=repo_root.as_posix())
+    subprocess.check_call(["twine", "check", "dist/*"], cwd=str(repo_root))
 
     return 0
 

--- a/tests/cpp/live_test_generate_jsoncpp.py
+++ b/tests/cpp/live_test_generate_jsoncpp.py
@@ -210,6 +210,7 @@ class Case:
             for example_path in example_paths),
         "Necessary since we need to re-use the test identifier "
         "for the example and the schemas")
+    @icontract.require(lambda rel_path: not rel_path.is_absolute())
     # yapf: enable
     def __init__(
             self, schema_path: pathlib.Path,
@@ -230,7 +231,7 @@ class Case:
         self.rel_path = rel_path
 
         self.executable_name = "{}_parse_serialize".format(
-            rel_path.as_posix().replace("/", "_"))
+            '_'.join(rel_path.parts))
 
 
 class Params:
@@ -348,8 +349,8 @@ def execute_case(case: Case, bin_dir: pathlib.Path) -> None:
 
         # yapf: disable
         proc = subprocess.Popen(
-            [(bin_dir / case.executable_name).as_posix(),
-             example_pth.as_posix()],
+            [str(bin_dir / case.executable_name),
+             str(example_pth)],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             universal_newlines=True)
         # yapf: enable
@@ -499,8 +500,8 @@ def main() -> None:
 
         build_dir.mkdir(exist_ok=True)
         subprocess.check_call(['cmake', '../src', '-DCMAKE_BUILD_TYPE=Debug'],
-                              cwd=build_dir.as_posix())
-        subprocess.check_call(['make', 'all'], cwd=build_dir.as_posix())
+                              cwd=str(build_dir))
+        subprocess.check_call(['make', 'all'], cwd=str(build_dir))
 
         ##
         # Run

--- a/tests/go/live_test_generate_jsonable.py
+++ b/tests/go/live_test_generate_jsonable.py
@@ -246,7 +246,7 @@ def execute_case(case: Case, gopath: pathlib.Path) -> None:
     (src_dir / "parse_serialize" / "main.go").chmod(mode=0o755)
 
     env = os.environ.copy()
-    env['GOPATH'] = gopath.as_posix()
+    env['GOPATH'] = str(gopath)
 
     ##
     # Validate
@@ -254,7 +254,7 @@ def execute_case(case: Case, gopath: pathlib.Path) -> None:
 
     say("go vet'ing the generated filies in {} ...".format(gopath))
     subprocess.check_call(['go', 'vet', '.'],
-                          cwd=(src_dir / "parse_serialize").as_posix(),
+                          cwd=str(src_dir / "parse_serialize"),
                           env=env)
 
     ##
@@ -263,7 +263,7 @@ def execute_case(case: Case, gopath: pathlib.Path) -> None:
 
     say("go build'ing {} ...".format(gopath))
     subprocess.check_call(['go', 'build', '.'],
-                          cwd=(src_dir / "parse_serialize").as_posix(),
+                          cwd=str(src_dir / "parse_serialize"),
                           env=env)
 
     ##
@@ -284,10 +284,8 @@ def execute_case(case: Case, gopath: pathlib.Path) -> None:
 
         # yapf: disable
         proc = subprocess.Popen(
-            [(
-                gopath / 'src' / 'parse_serialize' / 'parse_serialize'
-             ).as_posix(),
-             '-path', example_pth.as_posix()],
+            [str(gopath / 'src' / 'parse_serialize' / 'parse_serialize'),
+             '-path', str(example_pth)],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             universal_newlines=True)
         # yapf: enable

--- a/tests/py/live_test_generate_jsonable.py
+++ b/tests/py/live_test_generate_jsonable.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 from typing import Any, Sequence
 
 import icontract
@@ -226,13 +227,13 @@ def execute_case(case: Case, case_src_dir: pathlib.Path) -> None:
     ##
 
     say("Mypy'ing the generated filies in {} ...".format(case_src_dir))
-    subprocess.check_call(['mypy', '--strict', case_src_dir.as_posix()])
+    subprocess.check_call(['mypy', '--strict', str(case_src_dir)])
 
     say("doctest'ing the generated filies in {} ...".format(case_src_dir))
     for pth in sorted(case_src_dir.glob("**/*.py")):
-        subprocess.check_call(['python3', '-m', 'doctest',
-                               pth.as_posix()],
-                              cwd=case_src_dir.as_posix())
+        subprocess.check_call([sys.executable, '-m', 'doctest',
+                               str(pth)],
+                              cwd=str(case_src_dir))
 
     ##
     # Execute
@@ -252,12 +253,12 @@ def execute_case(case: Case, case_src_dir: pathlib.Path) -> None:
 
         env = os.environ.copy()
         env['PYTHONPATH'] = '{}:{}'.format(
-            os.environ.get('PYTHONPATH', ''), case_src_dir.as_posix())
+            os.environ.get('PYTHONPATH', ''), str(case_src_dir))
 
         # yapf: disable
         proc = subprocess.Popen(
-            [(module_dir / 'parse_serialize.py').as_posix(),
-             '--path', example_pth.as_posix()],
+            [str(module_dir / 'parse_serialize.py'),
+             '--path', str(example_pth)],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             env=env,
             universal_newlines=True)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -13,35 +13,32 @@ import tests.path
 
 class TestSchema(unittest.TestCase):
     def test_schema_from_invalid_mapping(self) -> None:  # pylint: disable=invalid-name
-        # Test with list
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            tmpfile.file.write('[]'.encode())  # type: ignore
-            tmpfile.file.flush()  # type: ignore
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Test with list
+            tmpfile = pathlib.Path(tmpdir) / "test-schema-with-list.yml"
+            tmpfile.write_text('[]')
 
             try:
-                mapry.parse.schema_from_json_file(
-                    path=pathlib.Path(tmpfile.name))
+                mapry.parse.schema_from_json_file(path=tmpfile)
             except mapry.validation.SchemaError as err:
                 self.assertEqual((
                     "{}#: Does not follow json schema: "
-                    "[] is not of type 'object'").format(tmpfile.name),
-                                 str(err))
+                    "[] is not of type 'object'").format(tmpfile), str(err))
 
-        # Test with name as object instead of string
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            tmpfile.file.write(  # type: ignore
+            # Test with name as object instead of string
+            tmpfile = pathlib.Path(tmpdir) / "name-as-object.yml"
+
+            tmpfile.write_text(
                 '{"name": {"unexpected": "value"}, '
-                '"description": "some description."}'.encode())
-            tmpfile.file.flush()  # type: ignore
+                '"description": "some description."}')
 
             try:
-                mapry.parse.schema_from_json_file(
-                    path=pathlib.Path(tmpfile.name))
+                mapry.parse.schema_from_json_file(path=tmpfile)
             except mapry.validation.SchemaError as err:
                 self.assertEqual(
                     str(err), "{}#/name: Does not follow json schema: "
                     "{{'unexpected': 'value'}} is not of type 'string'".format(
-                        tmpfile.name))
+                        tmpfile))
 
     def test_cases(self) -> None:  # pylint: disable=no-self-use
         cases_dir = tests.path.REPO_DIR / 'test_cases' / 'general'


### PR DESCRIPTION
The current code use extensively `.as_posix()` on `pathlib.Path`'s as
we developed and ran mapry only on Linux. This patch makes the necessary
changes so that mapry can now be run on Windows as well.