### PR TITLE
Released 1.0.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.0.0.3
+=======
+* Added support for Python 3.7 and 3.8
+* Updated code to comply with latest versions of mypy and pylint
+* Adapted for Windows (previously, mapry ran only on Linux)
+
 1.0.0.2
 =======
 * vendored date/tz.h to the repository for testing

--- a/mapry_meta.py
+++ b/mapry_meta.py
@@ -5,7 +5,7 @@ __description__ = (
     'Generate polyglot code for de/serializing object graphs '
     'from JSONable structures.')
 __url__ = 'http://github.com/Parquery/mapry'
-__version__ = '1.0.0.2'
+__version__ = '1.0.0.3'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Added support for Python 3.7 and 3.8
* Updated code to comply with latest versions of mypy and pylint
* Adapted for Windows (previously, mapry ran only on Linux)