### PR TITLE
Pinned icontract version in requirements-doc.txt

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,3 +2,7 @@ sphinx>=1.7.7,<2
 sphinx-autodoc-typehints>=1.3.0,<2
 sphinx-icontract>=1.0.0
 sphinx-rtd-theme>=0.4.1,<1
+
+# We need to pin icontract version since readthedocs for some reason picks an older version
+# which could not be installed on their remote servers.
+icontract>=2.3.6,<3


### PR DESCRIPTION
We need to pin icontract version since readthedocs for some reason
picks an older version which could not be installed on their remote
servers.